### PR TITLE
more tweaks

### DIFF
--- a/src/lib/components/MetaTags.svelte
+++ b/src/lib/components/MetaTags.svelte
@@ -11,6 +11,7 @@
 	 * @property {'website' | 'article'} [type] - Content type ('website' or 'article').
 	 * @property {string} [color] - Discord sidebar color (Hex code).
 	 * @property {boolean} [noIndex] - If true, hides page from Google.
+	 * @property {boolean} [appendSiteName] - If false, omits '| D-Scan Space!' suffix.
 	 */
 
 	/** @type {Props} */
@@ -22,13 +23,13 @@
 		showImage = true,
 		type = 'website',
 		color = '#101828',
-		noIndex = false
+		noIndex = false,
+		appendSiteName = true
 	} = $props();
 
 	// --- Derived State (Runes) ---
 
-	// Append site name automatically
-	let fullTitle = $derived(`${title} | D-Scan Space!`);
+	let fullTitle = $derived(appendSiteName ? `${title} | D-Scan Space!` : title);
 
 	// Get current absolute URL
 	let currentUrl = $derived($page.url.href);

--- a/src/routes/scan/[group]/[scan]/+page.svelte
+++ b/src/routes/scan/[group]/[scan]/+page.svelte
@@ -60,8 +60,6 @@
 				: typeof systemValue?.name === 'string'
 					? systemValue.name
 					: null;
-		const constellation =
-			typeof systemValue?.constellation === 'string' ? systemValue.constellation : null;
 		const region = typeof systemValue?.region === 'string' ? systemValue.region : null;
 		const security =
 			typeof systemValue?.security === 'number' ? systemValue.security.toFixed(2) : null;
@@ -72,12 +70,11 @@
 					.replace(/\.\d+Z$/, '')
 			: '';
 		const timeLabel = timestamp ? ` @ ${timestamp}` : '';
-		if (systemName || constellation || region) {
+		if (systemName || region) {
 			const securityLabel = security ?? '?';
 			const systemLabel = systemName ?? 'Unknown System';
-			const constellationLabel = constellation ?? 'Unknown Constellation';
 			const regionLabel = region ?? 'Unknown Region';
-			return `[${securityLabel}] ${systemLabel} > ${constellationLabel} > ${regionLabel}${timeLabel}`;
+			return `[${securityLabel}] ${systemLabel} > ${regionLabel}${timeLabel}`;
 		}
 		return `Unknown System${timeLabel}`;
 	});
@@ -156,7 +153,7 @@
 	});
 </script>
 
-<MetaTags title={scanTitle} description={scanSummary} showImage={false} />
+<MetaTags title={scanTitle} description={scanSummary} showImage={false} appendSiteName={false} />
 
 <div class="container mx-auto px-0">
 	{#if showCopiedToast}


### PR DESCRIPTION
This pull request introduces a minor improvement to the `MetaTags` component, making the site name suffix in page titles optional, and updates the scan page to use this new option. It also simplifies the scan title formatting by removing the constellation information.

Meta tag customization:

* Added an `appendSiteName` boolean prop to the `MetaTags` component in `MetaTags.svelte`, allowing pages to control whether the "| D-Scan Space!" suffix is appended to the page title. The default is `true`. [[1]](diffhunk://#diff-c7bd80bc79300998dbd290df8944c865e767ef087fea7a9e29d1b596404c5e8aR14) [[2]](diffhunk://#diff-c7bd80bc79300998dbd290df8944c865e767ef087fea7a9e29d1b596404c5e8aL25-R32)
* Updated the scan details page (`+page.svelte`) to pass `appendSiteName={false}` to `MetaTags`, so the site name is omitted from scan titles. ([src/routes/scan/[group]/[scan]/+page.svelteL159-R156](diffhunk://#diff-a51e481f8254e03e4ea4b892e1acfb09574c4975668a71392421227ae8604fd0L159-R156))

Scan title formatting:

* Removed the constellation information from the scan title and its formatting logic in `+page.svelte`, so titles now only display system name and region. ([src/routes/scan/[group]/[scan]/+page.svelteL63-L64](diffhunk://#diff-a51e481f8254e03e4ea4b892e1acfb09574c4975668a71392421227ae8604fd0L63-L64), [src/routes/scan/[group]/[scan]/+page.svelteL75-R77](diffhunk://#diff-a51e481f8254e03e4ea4b892e1acfb09574c4975668a71392421227ae8604fd0L75-R77))