### PR TITLE
fix fetch

### DIFF
--- a/src/lib/server/wrappers.js
+++ b/src/lib/server/wrappers.js
@@ -2,7 +2,7 @@ import { biomassCharacter } from '../database/characters.js';
 import { USER_AGENT, ESI_MAX_CONNECTIONS, ESI_TEST_FLAGS } from './constants.js';
 import { withSpan } from './tracer.js';
 import { recordEsiRequest, esiConcurrentRequests } from './metrics.js';
-import { Agent } from 'undici';
+import { Agent, fetch } from 'undici';
 import logger from '../logger.js';
 
 const esiAgent = new Agent({

--- a/tests/lib/server/wrappers.test.js
+++ b/tests/lib/server/wrappers.test.js
@@ -21,7 +21,8 @@ vi.mock('../../../src/lib/database/characters.js', () => ({
 }));
 
 const mocks = vi.hoisted(() => ({
-	agentClose: vi.fn()
+	agentClose: vi.fn(),
+	fetch: vi.fn()
 }));
 
 vi.mock('undici', () => ({
@@ -29,7 +30,8 @@ vi.mock('undici', () => ({
 		constructor() {
 			this.close = mocks.agentClose;
 		}
-	}
+	},
+	fetch: mocks.fetch
 }));
 
 import { fetchGET, fetchPOST } from '../../../src/lib/server/wrappers.js';
@@ -37,13 +39,9 @@ import { recordEsiRequest } from '../../../src/lib/server/metrics.js';
 import { biomassCharacter } from '../../../src/lib/database/characters.js';
 import { withSpan } from '../../../src/lib/server/tracer.js';
 
-// Mock global fetch
-// global.fetch = vi.fn(); // Move to beforeEach
-
 describe('wrappers', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
-		global.fetch = vi.fn();
 	});
 
 	describe('fetchGET', () => {
@@ -63,11 +61,11 @@ describe('wrappers', () => {
 				redirected: false,
 				type: 'basic'
 			};
-			global.fetch.mockResolvedValue(mockResponse);
+			mocks.fetch.mockResolvedValue(mockResponse);
 
 			const result = await fetchGET('https://esi.evetech.net/v1/characters/1/');
 
-			expect(global.fetch).toHaveBeenCalledWith(
+			expect(mocks.fetch).toHaveBeenCalledWith(
 				'https://esi.evetech.net/v1/characters/1/',
 				expect.objectContaining({ method: 'GET' })
 			);
@@ -97,12 +95,12 @@ describe('wrappers', () => {
 				}),
 				url: 'http://test.com'
 			};
-			global.fetch.mockResolvedValue(errorResponse);
+			mocks.fetch.mockResolvedValue(errorResponse);
 
 			const result = await fetchGET('http://test.com', 2);
 			expect(result).toBeNull();
 
-			expect(global.fetch).toHaveBeenCalledTimes(2);
+			expect(mocks.fetch).toHaveBeenCalledTimes(2);
 		});
 
 		it('should handle deleted character (404 with deleted error)', async () => {
@@ -120,7 +118,7 @@ describe('wrappers', () => {
 				}),
 				url: 'https://esi.evetech.net/v1/characters/123'
 			};
-			global.fetch.mockResolvedValue(deletedResponse);
+			mocks.fetch.mockResolvedValue(deletedResponse);
 
 			await fetchGET('https://esi.evetech.net/v1/characters/123');
 
@@ -143,7 +141,7 @@ describe('wrappers', () => {
 				}),
 				url: 'https://esi.evetech.net/v1/characters/456'
 			};
-			global.fetch.mockResolvedValue(deletedResponse);
+			mocks.fetch.mockResolvedValue(deletedResponse);
 
 			await fetchGET('https://esi.evetech.net/v1/characters/456');
 
@@ -178,11 +176,11 @@ describe('wrappers', () => {
 				redirected: false,
 				type: 'basic'
 			};
-			global.fetch.mockResolvedValue(mockResponse);
+			mocks.fetch.mockResolvedValue(mockResponse);
 
 			await fetchGETWithFlags('https://esi.evetech.net/v1/characters/1/');
 
-			expect(global.fetch).toHaveBeenCalledWith(
+			expect(mocks.fetch).toHaveBeenCalledWith(
 				'https://esi.evetech.net/v1/characters/1/',
 				expect.objectContaining({
 					headers: expect.objectContaining({ 'X-Compatibility-Date': '2099-01-01' })
@@ -204,7 +202,7 @@ describe('wrappers', () => {
 				}),
 				url: 'http://test.com'
 			};
-			global.fetch.mockResolvedValue(errorResponse);
+			mocks.fetch.mockResolvedValue(errorResponse);
 
 			const result = await fetchGET('http://test.com');
 			expect(result).toBeNull();
@@ -226,7 +224,7 @@ describe('wrappers', () => {
 				}),
 				url: 'http://test.com'
 			};
-			global.fetch.mockResolvedValue(errorResponse);
+			mocks.fetch.mockResolvedValue(errorResponse);
 
 			const result = await fetchGET('http://test.com', 1);
 			expect(result).toBeNull();
@@ -237,7 +235,7 @@ describe('wrappers', () => {
 		});
 
 		it('should handle network error (fetch throws) and decrement concurrency', async () => {
-			global.fetch.mockRejectedValueOnce(new TypeError('Network Error'));
+			mocks.fetch.mockRejectedValueOnce(new TypeError('Network Error'));
 			const { esiConcurrentRequests } = await import('../../../src/lib/server/metrics.js');
 
 			const result = await fetchGET('http://test.com', 1);
@@ -246,7 +244,7 @@ describe('wrappers', () => {
 		});
 
 		it('should add GET fetch failure event details', async () => {
-			global.fetch.mockRejectedValueOnce(new Error('Network Error'));
+			mocks.fetch.mockRejectedValueOnce(new Error('Network Error'));
 
 			const result = await fetchGET('http://test.com', 1);
 			expect(result).toBeNull();
@@ -275,7 +273,7 @@ describe('wrappers', () => {
 				}),
 				url: 'https://esi.evetech.net/v1/characters/'
 			};
-			global.fetch.mockResolvedValue(deletedResponse);
+			mocks.fetch.mockResolvedValue(deletedResponse);
 
 			await fetchGET('https://esi.evetech.net/v1/characters/');
 
@@ -297,7 +295,7 @@ describe('wrappers', () => {
 				}),
 				url: 'https://esi.evetech.net/v1/corporations/123'
 			};
-			global.fetch.mockResolvedValue(deletedResponse);
+			mocks.fetch.mockResolvedValue(deletedResponse);
 
 			await fetchGET('https://esi.evetech.net/v1/corporations/123');
 
@@ -306,7 +304,7 @@ describe('wrappers', () => {
 
 		it('should handle 429 rate limit and return null', async () => {
 			vi.useFakeTimers();
-			global.fetch.mockResolvedValue({
+			mocks.fetch.mockResolvedValue({
 				ok: false,
 				status: 429,
 				statusText: 'Too Many Requests',
@@ -332,7 +330,7 @@ describe('wrappers', () => {
 
 		it('should use default 60s wait when x-esi-error-limit-reset header is absent', async () => {
 			vi.useFakeTimers();
-			global.fetch.mockResolvedValue({
+			mocks.fetch.mockResolvedValue({
 				ok: false,
 				status: 429,
 				statusText: 'Too Many Requests',
@@ -357,7 +355,7 @@ describe('wrappers', () => {
 		});
 
 		it('should stringify unknown GET errors', async () => {
-			global.fetch.mockRejectedValueOnce({});
+			mocks.fetch.mockRejectedValueOnce({});
 
 			const result = await fetchGET('http://test.com', 1);
 			expect(result).toBeNull();
@@ -389,12 +387,12 @@ describe('wrappers', () => {
 				redirected: false,
 				type: 'basic'
 			};
-			global.fetch.mockResolvedValue(mockResponse);
+			mocks.fetch.mockResolvedValue(mockResponse);
 
 			const body = { ids: [1, 2] };
 			const result = await fetchPOST('https://esi.evetech.net/v1/universe/names/', body);
 
-			expect(global.fetch).toHaveBeenCalledWith(
+			expect(mocks.fetch).toHaveBeenCalledWith(
 				'https://esi.evetech.net/v1/universe/names/',
 				expect.objectContaining({
 					method: 'POST',
@@ -427,12 +425,12 @@ describe('wrappers', () => {
 				}),
 				url: 'http://test.com'
 			};
-			global.fetch.mockResolvedValue(errorResponse);
+			mocks.fetch.mockResolvedValue(errorResponse);
 
 			const result = await fetchPOST('http://test.com', {}, 2);
 			expect(result).toBeNull();
 
-			expect(global.fetch).toHaveBeenCalledTimes(2);
+			expect(mocks.fetch).toHaveBeenCalledTimes(2);
 		});
 
 		it('should handle deleted character (404 with deleted error)', async () => {
@@ -450,7 +448,7 @@ describe('wrappers', () => {
 				}),
 				url: 'https://esi.evetech.net/v1/characters/123'
 			};
-			global.fetch.mockResolvedValue(deletedResponse);
+			mocks.fetch.mockResolvedValue(deletedResponse);
 
 			await fetchPOST('https://esi.evetech.net/v1/characters/123', {});
 
@@ -460,7 +458,7 @@ describe('wrappers', () => {
 
 		it('should handle 429 rate limit and return null', async () => {
 			vi.useFakeTimers();
-			global.fetch.mockResolvedValue({
+			mocks.fetch.mockResolvedValue({
 				ok: false,
 				status: 429,
 				statusText: 'Too Many Requests',
@@ -486,7 +484,7 @@ describe('wrappers', () => {
 
 		it('should use default 60s wait when x-esi-error-limit-reset header is absent', async () => {
 			vi.useFakeTimers();
-			global.fetch.mockResolvedValue({
+			mocks.fetch.mockResolvedValue({
 				ok: false,
 				status: 429,
 				statusText: 'Too Many Requests',
@@ -525,7 +523,7 @@ describe('wrappers', () => {
 				}),
 				url: 'https://esi.evetech.net/v1/corporations/123'
 			};
-			global.fetch.mockResolvedValue(deletedResponse);
+			mocks.fetch.mockResolvedValue(deletedResponse);
 
 			await fetchPOST('https://esi.evetech.net/v1/corporations/123', {});
 
@@ -545,7 +543,7 @@ describe('wrappers', () => {
 				}),
 				url: 'http://test.com'
 			};
-			global.fetch.mockResolvedValue(errorResponse);
+			mocks.fetch.mockResolvedValue(errorResponse);
 
 			const result = await fetchPOST('http://test.com', {});
 			expect(result).toBeNull();
@@ -569,7 +567,7 @@ describe('wrappers', () => {
 				}),
 				url: 'http://test.com'
 			};
-			global.fetch.mockResolvedValue(errorResponse);
+			mocks.fetch.mockResolvedValue(errorResponse);
 
 			const result = await fetchPOST('http://test.com', {});
 			expect(result).toBeNull();
@@ -580,7 +578,7 @@ describe('wrappers', () => {
 		});
 
 		it('should handle network error (fetch throws) and decrement concurrency', async () => {
-			global.fetch.mockRejectedValueOnce(new TypeError('Network Error'));
+			mocks.fetch.mockRejectedValueOnce(new TypeError('Network Error'));
 			const { esiConcurrentRequests } = await import('../../../src/lib/server/metrics.js');
 
 			const result = await fetchPOST('http://test.com', {}, 1);
@@ -590,9 +588,9 @@ describe('wrappers', () => {
 
 		it('should handle POST network error fallback', async () => {
 			const error = new Error('Network Error');
-			global.fetch.mockRejectedValueOnce(error);
-			global.fetch.mockRejectedValueOnce(error);
-			global.fetch.mockRejectedValueOnce(error);
+			mocks.fetch.mockRejectedValueOnce(error);
+			mocks.fetch.mockRejectedValueOnce(error);
+			mocks.fetch.mockRejectedValueOnce(error);
 
 			const result = await fetchPOST('https://esi.evetech.net/v1/post', {});
 			expect(result).toBeNull();
@@ -622,7 +620,7 @@ describe('wrappers', () => {
 				redirected: false,
 				type: 'basic'
 			};
-			global.fetch.mockResolvedValue(mockResponse);
+			mocks.fetch.mockResolvedValue(mockResponse);
 
 			await fetchPOST('http://test.com', { a: 1 }, 1);
 
@@ -650,14 +648,14 @@ describe('wrappers', () => {
 				}),
 				url: 'http://test.com'
 			};
-			global.fetch.mockResolvedValue(mockResponse);
+			mocks.fetch.mockResolvedValue(mockResponse);
 
 			const result = await fetchPOST('http://test.com', {}, 1);
 			expect(result).toBeNull();
 		});
 
 		it('should stringify unknown POST errors', async () => {
-			global.fetch.mockRejectedValueOnce({});
+			mocks.fetch.mockRejectedValueOnce({});
 
 			const result = await fetchPOST('http://test.com', {}, 1);
 			expect(result).toBeNull();
@@ -687,11 +685,11 @@ describe('wrappers', () => {
 				redirected: false,
 				type: 'basic'
 			};
-			global.fetch.mockResolvedValue(mockResponse);
+			mocks.fetch.mockResolvedValue(mockResponse);
 
 			await fetchPOST('http://test.com', undefined, 1);
 
-			expect(global.fetch).toHaveBeenCalled();
+			expect(mocks.fetch).toHaveBeenCalled();
 		});
 	});
 
@@ -705,7 +703,7 @@ describe('wrappers', () => {
 
 	describe('createPreview', () => {
 		it('should handle null payload in error preview', async () => {
-			global.fetch.mockResolvedValueOnce({
+			mocks.fetch.mockResolvedValueOnce({
 				ok: false,
 				status: 500,
 				statusText: 'Internal Server Error',
@@ -718,7 +716,7 @@ describe('wrappers', () => {
 				url: 'https://esi.evetech.net/v1/test'
 			});
 
-			const result = await fetchGET('https://esi.evetech.net/v1/test');
+			const result = await fetchGET('https://esi.evetech.net/v1/test', 1);
 			expect(result).toBeNull();
 			expect(mockSpan.addEvent).toHaveBeenCalledWith(
 				'Fetch Failed',
@@ -744,7 +742,7 @@ describe('wrappers', () => {
 
 			for (const { url, type } of types) {
 				vi.clearAllMocks();
-				global.fetch.mockResolvedValueOnce({
+				mocks.fetch.mockResolvedValueOnce({
 					ok: true,
 					status: 200,
 					statusText: 'OK',


### PR DESCRIPTION
This pull request updates how the `fetch` function from the `undici` library is imported and mocked in both the server code and its tests. The main goal is to replace the use of the global `fetch` mock in tests with a more targeted mock of `undici`'s `fetch`, improving test isolation and accuracy.

Key changes include:

**Codebase Updates:**

* The `fetch` function is now imported directly from `undici` in `src/lib/server/wrappers.js`, rather than relying on a global fetch.

**Testing Improvements:**

* The test suite (`tests/lib/server/wrappers.test.js`) now mocks `undici`'s `fetch` instead of the global fetch, using a new `mocks.fetch` mock function. All test assertions and setup have been updated to use `mocks.fetch` throughout.
* All test cases that previously referenced or manipulated `global.fetch` have been updated to use `mocks.fetch`, ensuring that tests are now isolated from the global environment and more accurately reflect the actual code behavior. [[1]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L66-R68) [[2]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L100-R103) [[3]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L123-R121) [[4]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L146-R144) [[5]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L181-R183) [[6]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L207-R205) [[7]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L229-R227) [[8]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L240-R238) [[9]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L249-R247) [[10]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L278-R276) [[11]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L300-R298) [[12]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L309-R307) [[13]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L335-R333) [[14]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L360-R358) [[15]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L392-R395) [[16]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L430-R433) [[17]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L453-R451) [[18]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L463-R461) [[19]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L489-R487) [[20]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L528-R526) [[21]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L548-R546) [[22]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L572-R570) [[23]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L583-R581) [[24]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L593-R593) [[25]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L625-R623) [[26]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L653-R658) [[27]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L690-R692) [[28]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L708-R706) [[29]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L721-R719) [[30]](diffhunk://#diff-484ee41dadd49754dc7ccba4b3fd4e698e7d3144417781b95d5ed5ce1aef7c48L747-R745)
* Minor test code improvements, such as passing the retry count explicitly in a test to match the new function signature.

These changes make the codebase and tests more robust by ensuring that the correct `fetch` implementation is used and mocked, reducing the risk of side effects from global state.