### PR TITLE
group url redirect to last scan of group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "d-scan-space",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "d-scan-space",
-			"version": "1.2.4",
+			"version": "1.2.5",
 			"dependencies": {
 				"@auth/core": "^0.41.2",
 				"@auth/drizzle-adapter": "^1.11.2",
@@ -46,7 +46,7 @@
 				"pino-pretty": "^13.1.3",
 				"prettier": "^3.8.3",
 				"prettier-plugin-svelte": "^3.5.1",
-				"prettier-plugin-tailwindcss": "^0.7.3",
+				"prettier-plugin-tailwindcss": "^0.7.4",
 				"short-unique-id": "^5.3.2",
 				"svelte": "^5.55.5",
 				"svelte-check": "^4.4.6",
@@ -1348,22 +1348,22 @@
 			}
 		},
 		"node_modules/@grpc/proto-loader/node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+			"integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/codegen": "^2.0.5",
 				"@protobufjs/eventemitter": "^1.1.0",
 				"@protobufjs/fetch": "^1.1.0",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/inquire": "^1.1.1",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
 				"long": "^5.0.0"
 			},
@@ -2913,9 +2913,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
@@ -2941,9 +2941,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -2959,9 +2959,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
@@ -5350,9 +5350,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
@@ -6301,9 +6301,9 @@
 			}
 		},
 		"node_modules/jose": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-			"integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -6855,9 +6855,9 @@
 			}
 		},
 		"node_modules/oauth4webapi": {
-			"version": "3.8.5",
-			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
-			"integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+			"version": "3.8.6",
+			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+			"integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -7161,9 +7161,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7384,9 +7384,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-tailwindcss": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.3.tgz",
-			"integrity": "sha512-lckXaWWdo2ZVXoMoUO3WIBiz9hVY+YBEh1gYyMFfrWP9WZW/wpFXQKizHx7WrFQFMkcG0bGShdpp531X1n+qpg==",
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.4.tgz",
+			"integrity": "sha512-UKii4RjY05SNt/WQi6/NcOn/LsT0/ILLXsxygjbRg5/YZelsSu5jTqorYHPDGq4nZy5q5hpCu+XdGZ1xaJEQgw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.19"
@@ -7478,22 +7478,12 @@
 			"license": "MIT"
 		},
 		"node_modules/protobufjs": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-			"integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
+			"integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
 				"@types/node": ">=13.7.0",
 				"long": "^5.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "d-scan-space",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",
@@ -58,7 +58,7 @@
 		"pino-pretty": "^13.1.3",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^3.5.1",
-		"prettier-plugin-tailwindcss": "^0.7.3",
+		"prettier-plugin-tailwindcss": "^0.7.4",
 		"short-unique-id": "^5.3.2",
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.4.6",

--- a/src/routes/scan/[group]/+page.server.js
+++ b/src/routes/scan/[group]/+page.server.js
@@ -1,0 +1,40 @@
+import { getScansByGroupID, getScanGroupByID } from '$lib/database/scans.js';
+import { withSpan } from '$lib/server/tracer.js';
+import { error, redirect } from '@sveltejs/kit';
+
+export async function load(event) {
+	return await withSpan(
+		'route.scan_group.load',
+		async (span) => {
+			const { group } = event.params;
+
+			span.setAttributes({
+				'scan.group_id': group,
+				'page.type': 'scan_group_redirect'
+			});
+
+			const scanGroup = await getScanGroupByID(group);
+			if (!scanGroup) {
+				span.setAttributes({ 'scan.found': false, 'response.status': 404 });
+				throw error(404, 'Scan group not found');
+			}
+
+			const groupScans = await getScansByGroupID(group);
+			if (!groupScans || groupScans.length === 0) {
+				span.setAttributes({ 'scan.found': false, 'response.status': 404 });
+				throw error(404, 'No scans found in this group');
+			}
+
+			const latest = groupScans.reduce((a, b) =>
+				new Date(a.created_at) > new Date(b.created_at) ? a : b
+			);
+
+			span.setAttributes({ 'scan.id': latest.id, 'scan.found': true });
+
+			redirect(302, `/scan/${group}/${latest.id}`);
+		},
+		{ 'route.id': 'scan_group_redirect' },
+		{},
+		event
+	);
+}


### PR DESCRIPTION
This pull request introduces a new server-side route handler for redirecting users to the latest scan in a scan group and includes minor dependency updates. The main change is the addition of logic to look up a scan group and its associated scans, then redirect to the most recent scan if found, while handling errors and tracing for observability. Additionally, the `prettier-plugin-tailwindcss` dependency is updated, and the package version is incremented.

**New scan group redirect logic:**

* Added `src/routes/scan/[group]/+page.server.js` to handle loading scan groups by ID, retrieving associated scans, and redirecting to the latest scan in the group. The implementation includes error handling for missing groups or scans and uses tracing for observability. ([src/routes/scan/[group]/+page.server.jsR1-R40](diffhunk://#diff-be7f290c32b84e2000b1843f2e5d568a67176a7ee524dde86b9d5dbe273e6f53R1-R40))

**Dependency and version updates:**

* Updated `prettier-plugin-tailwindcss` dependency from version `0.7.3` to `0.7.4` in `package.json`.
* Bumped the project version from `1.2.4` to `1.2.5` in `package.json`.